### PR TITLE
Restructure documentation.md information flow

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -310,9 +310,14 @@ There are several files used to configure various aspects of the system.
 * `gradle.properties`, `gradle-wrapper.properties`: Contains the Gradle and Gradle wrapper configuration.
 * `package.json`: Contains the front-end third-party dependencies specification, as well as configurations for automated tasks/routines to be run via NPM.
 * `angular.json`: Contains the Angular application configuration.
-* `component.yml`: GitHub Action configuration for component tests.
-* `e2e.yml`: GitHub Action configuration for E2E tests.
-* `lnp.yml`: GitHub Action configuration for load & performance tests.
+
+**GitHub Actions**: These are workflow files for GitHub Actions. They are placed under `.github/workflows` directory.
+
+* `component.yml`: Configuration for component tests.
+* `e2e.yml`: Configuration for E2E tests.
+* `e2e-cross.yml`: Configuration for cross-browser E2E tests.
+* `lnp.yml`: Configuration for load & performance tests.
+* `dev-docs.yml`: Configuration for developer documentation site.
 
 **Static Analysis**: These are used to maintain code quality and measure code coverage. See [Static Analysis](static-analysis.md).
 * `static-analysis/*`: Contains most of the configuration files for all the different static analysis tools.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,44 +4,52 @@
 
 # Documentation
 
-This project uses [MarkBind](https://markbind.org/) for developer documentation. MarkBind is used to create a static site, and can parse markdown, GitHub Flavoured Markdown and more.
+This project uses [MarkBind](https://markbind.org/) for developer documentation. MarkBind is used to create a static site, and can parse markdown, GitHub Flavoured Markdown, and more.
+
+All the commands in this document are assumed to be run from the `/docs` folder, unless specified otherwise.
+
+## Installation
+
+1. Install `Node.js` (minimum version 12).
+1. Run `npm ci` to install the necessary tools to build documentation, including MarkBind.
+
+<box type="tip" light>
+
+You can also use a globally installed MarkBind if you have one. Make sure to use version `3.*.*`.
+</box>
+
 ## Quickstart
 
-To preview changes to documentation on MarkBind:
+Run the following command to view the site locally:
+```sh
+npm run serve
 
-1. Install `npm` and `Node.js` (version 12 or higher)
-1. Navigate to the `/docs` folder in your fork of the TEAMMATES repository
-1. Run `npm ci` to install the necessary tools to build documentation, such as MarkBind.
-1. Use `npm run serve` to view the site locally. The live preview should update automatically to reflect changes you make to the docs.
+# Alternative if you wish to use a globally installed MarkBind
+markbind serve
+```
+The live preview will be available at `localhost:8080` by default and should update automatically to reflect changes you make to the docs. If you wish to use another port (e.g. `8090`), use the `-p` flag as follows:
+```sh
+npm run serve -- -p 8090
+markbind serve -p 8090
+```
 
-Editing the docs is similar to how you edit any Markdown file. For most changes, knowledge of Markdown is sufficient. However, MarkBind also supports:
+Working with a MarkBind page is almost exactly the same as working with a standard Markdown page, with the following additional pointers:
 
-1. [Content reuse: reusing and including portions of documents in other documents](https://markbind.org/userGuide/reusingContents.html)
-1. [Expandable panels](https://markbind.org/userGuide/components/presentation.html#panels)
-1. [Support for PUML diagrams](https://markbind.org/userGuide/components/imagesAndDiagrams.html#diagrams)
-1. [Additional text formatting](https://markbind.org/userGuide/markBindSyntaxOverview.html)
+1. You may want to add `<frontmatter>` code block at the top of the page. For example, setting `title` allows for the page to be titled as such instead of following the file name. Refer [here](https://markbind.org/userGuide/tweakingThePageStructure.html#front-matter) for more details.
+   ```markdown
+   <frontmatter>
+     title: "YOUR TITLE HERE"
+   </frontmatter>
+   ```
+1. If you are adding a new page and want to include it in the site navigation, you can do so by including the link at the appropriate location in <code>_markbind/layouts/default.md</code>.
+1. You can take advantage of MarkBind's additional features such as:
+   1. [Content reuse: reusing and including portions of documents in other documents](https://markbind.org/userGuide/reusingContents.html)
+   1. [Expandable panels](https://markbind.org/userGuide/components/presentation.html#panels)
+   1. [Support for PUML diagrams](https://markbind.org/userGuide/components/imagesAndDiagrams.html#diagrams)
+   1. [Additional text formatting](https://markbind.org/userGuide/markBindSyntaxOverview.html)
+  
+You can refer to [MarkBind user guide](https://markbind.org/userGuide) for more information.
 
-Read the [MarkBind user guide](https://markbind.org/userGuide) if you need more information.
+## Deploying to GitHub pages
 
-## Adding pages to the developer guide
-
-1. Create the page in the docs folder as a `.md` file.
-1. Add content as desired.
-    <box type="tip" light>
-
-    You may want to include the following code (or a variant of it)
-
-    ```markdown
-    <frontmatter>
-    title: "YOUR TITLE HERE"
-    </frontmatter>
-    ```
-
-    The `<frontmatter>` block assigns the name of the file to title (allowing it to be searched by this name in the dev docs and changes the title of the html file).
-
-    </box>
-1. Add the page to the site navigation, by including the link at the appropriate location in <code>_markbind/layouts/default.md</code>.
-
-## Deploying to Github pages
-
-Documentation is automatically deployed after each push to `master` branch, as configured in `dev-docs.yml`. For more details see [this section of the MarkBind user guide](https://markbind.org/userGuide/deployingTheSite.html).
+Documentation is automatically deployed after each push to `master` branch, as configured in `dev-docs.yml`. For more details, refer [here](https://markbind.org/userGuide/deployingTheSite.html).


### PR DESCRIPTION
This particular page `documentation.md` needs some non-trivial restructure, and I figure that requesting changes through reviews will take too long.

Do take a look and you can suggest more changes as necessary.